### PR TITLE
Fixed checksum: high byte had not been taken into account, leading to…

### DIFF
--- a/sds011.py
+++ b/sds011.py
@@ -94,7 +94,7 @@ class SDS011:
             *data, checksum, tail = struct.unpack('<HHBBBs', packet)
             self._pm25 = data[0]/10.0
             self._pm10 = data[1]/10.0
-            checksum_OK = (checksum == (sum(data) % 256))
+            checksum_OK = (checksum == (sum(data) + (data[0]>>8) + (data[1]>>8))  % 256)
             tail_OK = tail == b'\xab'
             self._packet_status = True if (checksum_OK and tail_OK) else False
         except Exception as e:


### PR DESCRIPTION
… error meesage when values exceed 25.5

Hi Alexandre,
many thanks. Works well for moderate values and helped me a lot, but says "received corrupted data" although values are fine but exceed 25.5, because data[0] and data[1] are two bytes, but you do not take the higher byte into account for your checksum.
Regards
cjosee